### PR TITLE
Move parquet into serializer trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-array",
  "arrow-schema",
  "axum",
  "chrono",
@@ -517,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytecount"
@@ -655,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1276,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2248,9 +2249,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "4c8cea6b35bcceb099f30173754403d2eba0a5dc18cea3630fccd88251909288"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "analytics-collector"
-version = "1.1.0-dev"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2024"
 
 [dependencies]
 anyhow = { version = "1.0.98" }
-arrow = { version = "55.2.0" }
-arrow-schema = "55.2.0"
+arrow = { version = "55.1.0" }
+arrow-array = { version = "55.2.0" }
+arrow-schema = { version = "55.2.0" }
 axum = { version = "0.8.4" }
 chrono = { version = "0.4.41", features = ["serde"] }
-futures-util = "0.3.31"
+futures-util = { version = "0.3.31" }
 jsonschema = { version = "0.30.0" }
 libsql = { version = "0.9.11", default-features = false, features = ["core", "serde", "stream"] }
 parquet = { version = "55.2.0", features = ["arrow"] }
@@ -19,10 +20,10 @@ rust-database-common = { git = "https://github.com/corybuecker/rust-database-com
 rust-web-common = { git = "https://github.com/corybuecker/rust-web-common", branch = "main" }
 serde = { version = "1.0.219" }
 serde_json = { version = "1.0.140" }
-thiserror = "2.0.12"
+thiserror = { version = "2.0.12" }
 tokio = { version = "1.45.0", default-features = false, features = ["rt-multi-thread", "tracing", "macros", "signal", "fs"] }
 tower = { version = "0.5.2" }
 tower-http = { version = "0.6.4", features = ["trace"] }
 tracing = { version = "0.1.41" }
-urlencoding = "2.1.3"
+urlencoding = { version = "2.1.3" }
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analytics-collector"
-version = "1.1.0-dev"
+version = "1.1.0"
 edition = "2024"
 
 [dependencies]

--- a/src/exporter/parquet.rs
+++ b/src/exporter/parquet.rs
@@ -1,12 +1,9 @@
-use crate::{exporter::Exporter, storage::memory::flush};
-use arrow::{
-    array::{RecordBatch, StringArray},
-    datatypes::Field,
-};
-use arrow_array::ArrayRef;
-use arrow_schema::{Schema, SchemaBuilder};
+mod schema;
+
+use crate::exporter::Exporter;
 use chrono::{DateTime, Utc};
 use parquet::arrow::ArrowWriter;
+use schema::generate_record_batch;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -16,33 +13,6 @@ pub struct ParquetExporter<'a> {
     pub last_export_at: DateTime<Utc>,
 }
 
-fn schema() -> Arc<Schema> {
-    let mut builder = SchemaBuilder::new();
-
-    let event_fields = vec![
-        Field::new("ts", arrow::datatypes::DataType::Utf8, true),
-        Field::new("entity", arrow::datatypes::DataType::Utf8, false),
-        Field::new("action", arrow::datatypes::DataType::Utf8, false),
-        Field::new("path", arrow::datatypes::DataType::Utf8, true),
-        Field::new("app_id", arrow::datatypes::DataType::Utf8, false),
-    ];
-
-    builder.push(Field::new("id", arrow::datatypes::DataType::Utf8, false));
-    builder.push(Field::new_struct("event", event_fields, false));
-    builder.push(Field::new(
-        "recorded_at",
-        arrow::datatypes::DataType::Utf8,
-        false,
-    ));
-    builder.push(Field::new(
-        "recorded_by",
-        arrow::datatypes::DataType::Utf8,
-        true,
-    ));
-
-    Arc::new(builder.finish())
-}
-
 impl Exporter for ParquetExporter<'_> {
     async fn publish(
         &mut self,
@@ -50,91 +20,13 @@ impl Exporter for ParquetExporter<'_> {
         source: Arc<libsql::Connection>,
     ) -> anyhow::Result<usize> {
         info!("Starting parquet export");
-        debug!("Querying events from database");
-        let mut id_values = Vec::<String>::new();
 
-        let mut event_ts_values = Vec::<Option<String>>::new();
-        let mut event_entity_values = Vec::<String>::new();
-        let mut event_action_values = Vec::<String>::new();
-        let mut event_path_values = Vec::<Option<String>>::new();
-        let mut event_app_id_values = Vec::<String>::new();
+        let (record_batch, row_count) = generate_record_batch(source.clone()).await?;
 
-        let mut recorded_at_values = Vec::<String>::new();
-        let mut recorded_by_values = Vec::<Option<String>>::new();
-
-        for event_record in flush(source.clone()).await? {
-            id_values.push(event_record.id);
-
-            event_ts_values.push(event_record.event.ts.map(|t| t.to_rfc3339()));
-            event_entity_values.push(event_record.event.entity);
-            event_action_values.push(event_record.event.action);
-            event_path_values.push(event_record.event.path);
-            event_app_id_values.push(event_record.event.app_id);
-
-            recorded_at_values.push(event_record.recorded_at.to_rfc3339());
-            recorded_by_values.push(event_record.recorded_by);
-        }
-
-        let event_values = arrow_array::StructArray::from(vec![
-            (
-                Arc::new(arrow_schema::Field::new(
-                    "ts",
-                    arrow_schema::DataType::Utf8,
-                    true,
-                )),
-                (Arc::new(arrow_array::StringArray::from(event_ts_values)) as ArrayRef),
-            ),
-            (
-                Arc::new(Field::new(
-                    "entity",
-                    arrow::datatypes::DataType::Utf8,
-                    false,
-                )),
-                Arc::new(StringArray::from(event_entity_values)),
-            ),
-            (
-                Arc::new(Field::new(
-                    "action",
-                    arrow::datatypes::DataType::Utf8,
-                    false,
-                )),
-                Arc::new(StringArray::from(event_action_values)),
-            ),
-            (
-                Arc::new(Field::new("path", arrow::datatypes::DataType::Utf8, true)),
-                Arc::new(StringArray::from(event_path_values)),
-            ),
-            (
-                Arc::new(Field::new(
-                    "app_id",
-                    arrow::datatypes::DataType::Utf8,
-                    false,
-                )),
-                Arc::new(StringArray::from(event_app_id_values)),
-            ),
-        ]);
-
-        let row_count = id_values.len();
-
-        info!("Processed {} total rows from database", row_count);
-
-        debug!("Creating RecordBatch with {} rows", row_count);
-        let parquet_writer = RecordBatch::try_new(
-            schema(),
-            vec![
-                Arc::new(StringArray::from(id_values)),
-                Arc::new(event_values),
-                Arc::new(StringArray::from(recorded_at_values)),
-                Arc::new(StringArray::from(recorded_by_values)),
-            ],
-        )?;
-
-        debug!("Initializing parquet writer");
         let mut buffer = Vec::<u8>::new();
-        let mut writer = ArrowWriter::try_new(&mut buffer, parquet_writer.schema(), None)?;
+        let mut writer = ArrowWriter::try_new(&mut buffer, record_batch.schema(), None)?;
 
-        debug!("Writing RecordBatch to parquet format");
-        writer.write(&parquet_writer)?;
+        writer.write(&record_batch)?;
         writer.close()?;
 
         debug!("Parquet data written, buffer size: {} bytes", buffer.len());

--- a/src/exporter/parquet/schema.rs
+++ b/src/exporter/parquet/schema.rs
@@ -1,0 +1,120 @@
+use anyhow::{Result, anyhow};
+use arrow_array::{ArrayRef, RecordBatch, StringArray};
+use arrow_schema::{Field, Schema, SchemaBuilder};
+use libsql::Connection;
+use std::sync::Arc;
+use tracing::info;
+
+use crate::storage::memory::flush;
+
+pub fn generate_schema() -> Arc<Schema> {
+    let mut builder = SchemaBuilder::new();
+
+    let event_fields = vec![
+        Field::new("ts", arrow::datatypes::DataType::Utf8, true),
+        Field::new("entity", arrow::datatypes::DataType::Utf8, false),
+        Field::new("action", arrow::datatypes::DataType::Utf8, false),
+        Field::new("path", arrow::datatypes::DataType::Utf8, true),
+        Field::new("app_id", arrow::datatypes::DataType::Utf8, false),
+    ];
+
+    builder.push(Field::new("id", arrow::datatypes::DataType::Utf8, false));
+    builder.push(Field::new_struct("event", event_fields, false));
+    builder.push(Field::new(
+        "recorded_at",
+        arrow::datatypes::DataType::Utf8,
+        false,
+    ));
+    builder.push(Field::new(
+        "recorded_by",
+        arrow::datatypes::DataType::Utf8,
+        true,
+    ));
+
+    Arc::new(builder.finish())
+}
+
+pub async fn generate_record_batch(
+    source: Arc<Connection>,
+) -> Result<(arrow_array::RecordBatch, usize)> {
+    let mut id_values = Vec::<String>::new();
+
+    let mut event_ts_values = Vec::<Option<String>>::new();
+    let mut event_entity_values = Vec::<String>::new();
+    let mut event_action_values = Vec::<String>::new();
+    let mut event_path_values = Vec::<Option<String>>::new();
+    let mut event_app_id_values = Vec::<String>::new();
+
+    let mut recorded_at_values = Vec::<String>::new();
+    let mut recorded_by_values = Vec::<Option<String>>::new();
+
+    for event_record in flush(source.clone()).await? {
+        id_values.push(event_record.id);
+
+        event_ts_values.push(event_record.event.ts.map(|t| t.to_rfc3339()));
+        event_entity_values.push(event_record.event.entity);
+        event_action_values.push(event_record.event.action);
+        event_path_values.push(event_record.event.path);
+        event_app_id_values.push(event_record.event.app_id);
+
+        recorded_at_values.push(event_record.recorded_at.to_rfc3339());
+        recorded_by_values.push(event_record.recorded_by);
+    }
+
+    let event_values = arrow_array::StructArray::from(vec![
+        (
+            Arc::new(arrow_schema::Field::new(
+                "ts",
+                arrow_schema::DataType::Utf8,
+                true,
+            )),
+            (Arc::new(arrow_array::StringArray::from(event_ts_values)) as ArrayRef),
+        ),
+        (
+            Arc::new(Field::new(
+                "entity",
+                arrow::datatypes::DataType::Utf8,
+                false,
+            )),
+            Arc::new(StringArray::from(event_entity_values)),
+        ),
+        (
+            Arc::new(Field::new(
+                "action",
+                arrow::datatypes::DataType::Utf8,
+                false,
+            )),
+            Arc::new(StringArray::from(event_action_values)),
+        ),
+        (
+            Arc::new(Field::new("path", arrow::datatypes::DataType::Utf8, true)),
+            Arc::new(StringArray::from(event_path_values)),
+        ),
+        (
+            Arc::new(Field::new(
+                "app_id",
+                arrow::datatypes::DataType::Utf8,
+                false,
+            )),
+            Arc::new(StringArray::from(event_app_id_values)),
+        ),
+    ]);
+
+    let row_count = id_values.len();
+
+    info!("Processed {} total rows from database", row_count);
+
+    Ok((
+        RecordBatch::try_new(
+            generate_schema(),
+            vec![
+                Arc::new(StringArray::from(id_values)),
+                Arc::new(event_values),
+                Arc::new(StringArray::from(recorded_at_values)),
+                Arc::new(StringArray::from(recorded_by_values)),
+            ],
+        )
+        .map_err(|e| anyhow!("{:?}", e))?,
+        row_count,
+    ))
+}

--- a/src/exporter/parquet/serializer.rs
+++ b/src/exporter/parquet/serializer.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use parquet::arrow::ArrowWriter;
+use tracing::debug;
+
+use crate::storage::EventSerializer;
+
+use super::schema::generate_record_batch;
+
+pub struct ParqetSerializer;
+
+impl EventSerializer for ParqetSerializer {
+    fn to_bytes<'a>(
+        &self,
+        event_records: impl IntoIterator<Item = &'a crate::storage::memory::EventRecord>,
+    ) -> Result<(Vec<u8>, usize)> {
+        let (record_batch, row_count) = generate_record_batch(event_records)?;
+
+        let mut buffer = Vec::<u8>::new();
+        let mut writer = ArrowWriter::try_new(&mut buffer, record_batch.schema(), None)?;
+
+        writer.write(&record_batch)?;
+        writer.close()?;
+
+        debug!("Parquet data written, buffer size: {} bytes", buffer.len());
+
+        Ok((buffer, row_count))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,10 +259,14 @@ async fn periodic_parquet_export_handler(connection: Arc<libsql::Connection>) ->
         ));
 
         match handle.await {
-            Err(err) => tracing::error!("error {}", err),
+            Err(err) => {
+                tracing::error!("error {}", err);
+                continue;
+            }
             Ok(result) => {
                 if let Err(err) = result {
-                    tracing::error!("error {}", err)
+                    tracing::error!("error {}", err);
+                    continue;
                 }
             }
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,9 @@
 pub mod google_storage;
 pub mod memory;
 
+use anyhow::Result;
+use memory::EventRecord;
+
 pub const SCHEMA: &str = r#"
 CREATE TABLE events (
     id TEXT PRIMARY KEY NOT NULL,
@@ -9,3 +12,10 @@ CREATE TABLE events (
     event JSONB NOT NULL
 );
 "#;
+
+pub trait EventSerializer {
+    fn to_bytes<'a>(
+        &self,
+        event_records: impl IntoIterator<Item = &'a EventRecord>,
+    ) -> Result<(Vec<u8>, usize)>;
+}


### PR DESCRIPTION
This PR moves the parquet functionality into the serializer trait as part of issue #120.

## Changes
- Updated Cargo dependencies
- Moved parquet serialization logic into the serializer trait

This refactoring improves the code organization by consolidating serialization logic into a single trait interface.